### PR TITLE
[Feat] 가상 피팅 serializer 구현

### DIFF
--- a/config/urls.py
+++ b/config/urls.py
@@ -19,4 +19,5 @@ urlpatterns = [
     path('health/', health_check, name='health_check'),
     path('', include('django_prometheus.urls')),  # /metrics endpoint
     path('', include('analyses.urls')),
+    path('api/v1/', include('fittings.urls')),
 ] + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)

--- a/fittings/serializers.py
+++ b/fittings/serializers.py
@@ -1,0 +1,43 @@
+from rest_framework import serializers
+from .models import FittingImage
+
+class FittingImageSerializer(serializers.ModelSerializer):
+    # 명세서의 필드명과 일치시키기 위해 추가 필드 정의
+    fitting_image_id = serializers.IntegerField(source='id', read_only=True)
+    status = serializers.SerializerMethodField()
+    polling = serializers.SerializerMethodField()
+
+    class Meta:
+        model = FittingImage
+        fields = ['fitting_image_id', 'status', 'fitting_image_url', 'polling']
+
+    # 모델의 소문자 상태값을 명세서의 대문자 규격으로 변환
+    def get_status(self, obj):
+        return obj.fitting_image_status.upper()
+
+    # 명세서의 polling 경로 구조를 동적으로 생성
+    def get_polling(self, obj):
+        return {
+            "status_url": f"/api/v1/fitting-images/{obj.id}/status",
+            "result_url": f"/api/v1/fitting-images/{obj.id}"
+        }
+class FittingStatusSerializer(serializers.ModelSerializer):
+    status = serializers.SerializerMethodField()
+    progress = serializers.SerializerMethodField()
+    updated_at = serializers.DateTimeField(format="%Y-%m-%dT%H:%M:%S")
+
+    class Meta:
+        model = FittingImage
+        fields = ['status', 'progress', 'updated_at']
+
+    def get_status(self, obj):
+        return obj.fitting_image_status.upper()
+
+    def get_progress(self, obj):
+        if obj.fitting_image_status == FittingImage.Status.RUNNING:
+            return 40
+        elif obj.fitting_image_status == FittingImage.Status.DONE:
+            return 100
+        elif obj.fitting_image_status == FittingImage.Status.FAILED:
+            return 0
+        return 0 

--- a/fittings/urls.py
+++ b/fittings/urls.py
@@ -2,10 +2,7 @@ from django.urls import path
 from .views import FittingRequestView, FittingStatusView, FittingResultView
 
 urlpatterns = [
-    # 가상 피팅 요청
-    path('fitting-images', FittingRequestView.as_view(), name='fitting-request'),
-    # 가상 피팅 상태 조회
-    path('fitting-images/<int:fitting_image_id>/status', FittingStatusView.as_view(), name='fitting-status'),
-    # 가상 피팅 결과 조회
-    path('fitting-images/<int:fitting_image_id>', FittingResultView.as_view(), name='fitting-result'),
+    path('fitting-images/', FittingRequestView.as_view(), name='fitting-request'),
+    path('fitting-images/<int:fitting_image_id>/status/', FittingStatusView.as_view(), name='fitting-status'),
+    path('fitting-images/<int:fitting_image_id>/', FittingResultView.as_view(), name='fitting-result'),
 ]

--- a/fittings/views.py
+++ b/fittings/views.py
@@ -3,6 +3,7 @@ from rest_framework.response import Response
 from rest_framework import status
 from django.shortcuts import get_object_or_404
 from .models import FittingImage
+from .serializers import FittingImageSerializer, FittingStatusSerializer
 from .tasks import process_fitting_task
 
 class FittingRequestView(APIView):
@@ -13,27 +14,20 @@ class FittingRequestView(APIView):
         # 명세서의 Request Body 반영: detected_object_id, product_id, user_image_url
         product_id = request.data.get('product_id')
         user_image_url = request.data.get('user_image_url')
+        user_image_id = request.data.get('user_image_id')
         
         # 1. DB 레코드 생성 (ERD의 fitting_image 테이블 기반)
         fitting = FittingImage.objects.create(
             product_id=product_id,
-            # user_image_id는 명세서상 user_image_url을 받아 처리하므로 
-            # 프로젝트 로직에 따라 URL 저장 혹은 ID 매핑 필요
+            user_image_id=user_image_id,
             fitting_image_status=FittingImage.Status.PENDING
         )
 
         # 2. Celery 비동기 작업 시작
         process_fitting_task.delay(fitting.id)
 
-        # 3. 명세서 규격에 맞는 Response (201 Created)
-        return Response({
-            "fitting_image_id": fitting.id,
-            "status": "PENDING",
-            "polling": {
-                "status_url": f"/api/v1/fitting-images/{fitting.id}/status",
-                "result_url": f"/api/v1/fitting-images/{fitting.id}"
-            }
-        }, status=status.HTTP_201_CREATED)
+        serializer = FittingImageSerializer(fitting)
+        return Response(serializer.data, status=status.HTTP_201_CREATED)
 
 class FittingStatusView(APIView):
     """
@@ -42,12 +36,8 @@ class FittingStatusView(APIView):
     def get(self, request, fitting_image_id):
         fitting = get_object_or_404(FittingImage, id=fitting_image_id)
         
-        # 명세서 반영: status, progress, updated_at
-        return Response({
-            "status": "RUNNING" if fitting.fitting_image_status == FittingImage.Status.RUNNING else fitting.fitting_image_status.upper(),
-            "progress": 40 if fitting.fitting_image_status == FittingImage.Status.RUNNING else 100, # 예시 데이터
-            "updated_at": fitting.updated_at.isoformat()
-        }, status=status.HTTP_200_OK)
+        serializer = FittingStatusSerializer(fitting)
+        return Response(serializer.data, status=status.HTTP_200_OK)
 
 class FittingResultView(APIView):
     """
@@ -56,10 +46,5 @@ class FittingResultView(APIView):
     def get(self, request, fitting_image_id):
         fitting = get_object_or_404(FittingImage, id=fitting_image_id)
         
-        # 명세서 반영: fitting_image_id, status, fitting_image_url, completed_at
-        return Response({
-            "fitting_image_id": fitting.id,
-            "status": "DONE" if fitting.fitting_image_status == FittingImage.Status.DONE else fitting.fitting_image_status.upper(),
-            "fitting_image_url": fitting.fitting_image_url,
-            "completed_at": fitting.updated_at.isoformat() if fitting.fitting_image_status == FittingImage.Status.DONE else None
-        }, status=status.HTTP_200_OK)
+        serializer = FittingImageSerializer(fitting)
+        return Response(serializer.data, status=status.HTTP_200_OK)


### PR DESCRIPTION
## #️⃣ 연관된 이슈

#43 

## #️⃣ 작업 내용
fittings/serializers.py 파일에 코드 추가 내용은 다음과 같습니다. 
FittingImageSerializer: 피팅 요청 및 결과 조회를 위한 공통 규격 적용.
FittingStatusSerializer: 진행률(progress) 및 상태 확인을 위한 전용 규격 적용.

위 추가한 내용을 views.py, tasks.py에 적용하여 코드를 간단하게 수정했습니다.

config/urls.py 파일에 코드를 추가하여 fittings 앱의 URL들을 'api/v1/' 경로 아래에 포함시키는 작업을 했습니다.
/api/v1/fitting-images/ 경로 아래 요청 생성, 상태 조회, 결과 조회 엔드포인트 연결.

## #️⃣ 테스트 결과

DB 검증: MySQL Workbench에서 DESC fitting_image를 통해 테이블 구조 일치 확인.
URL 검증: /api/v1/fitting-images/ 접속 시 DRF 시스템이 정상적으로 요청을 수신하는 것 확인 (403 Forbidden 및 Allow 헤더 확인 완료).

## #️⃣ 스크린샷 (선택)
<img width="1195" height="777" alt="스크린샷 2026-01-12 201413" src="https://github.com/user-attachments/assets/43233b4d-0c81-4fbf-9dd0-4ab205b990fe" /> 