### PR TITLE
주문 목록 조회 기능 구현

### DIFF
--- a/orders/serializers.py
+++ b/orders/serializers.py
@@ -14,6 +14,17 @@ class OrderSerializer(serializers.ModelSerializer):
         ret['order_id'] = ret.pop('id')
         return ret 
 
+class OrderListSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Order
+        fields = ['id', 'total_price', 'created_at']
+        read_only_fields = ['id', 'total_price', 'created_at']
+    def to_representation(self, instance):
+        ret = super().to_representation(instance)
+        # Rename 'id' to 'order_id'
+        ret['order_id'] = ret.pop('id')
+        return ret
+
 
 class OrderCreateSerializer(serializers.ModelSerializer):
     cart_item_ids = serializers.ListField(
@@ -94,4 +105,4 @@ class OrderCreateSerializer(serializers.ModelSerializer):
     
     def to_representation(self, instance):
         # reuse OrderSerializer's representation for consistency
-        return OrderSerializer(instance).data
+        return OrderSerializer(instance).data 

--- a/orders/views.py
+++ b/orders/views.py
@@ -1,17 +1,47 @@
 from rest_framework import viewsets, status, permissions
 from rest_framework.response import Response
+from rest_framework import mixins
+from rest_framework.pagination import CursorPagination
 from .models import Order
-from .serializers import OrderCreateSerializer, OrderSerializer
+from .serializers import OrderCreateSerializer, OrderSerializer, OrderListSerializer
 
-class OrderViewSet(viewsets.GenericViewSet):
+class OrderCursorPagination(CursorPagination):
+    ordering = '-created_at'
+    page_size_query_param = 'limit'
+
+    def get_paginated_response(self, data):
+        next_url = self.get_next_link()
+        next_cursor = None 
+        # 다음 페이지가 있는 경우 URL에서 cursor 값만 추출 
+        if next_url:
+            from urllib.parse import urlparse, parse_qs
+            parsed = urlparse(next_url)
+            # cursor 파라미터 값 추출 
+            next_cursor = parse_qs(parsed.query).get('cursor', [None])[0]
+
+        return Response({
+            'orders': data,
+            'next_cursor': next_cursor,
+        })
+
+class OrderViewSet(mixins.ListModelMixin, viewsets.GenericViewSet):
     permission_classes = [permissions.IsAuthenticated]
-    
+    pagination_class = OrderCursorPagination # 위에서 만든 클래스 연결 
+
     def get_queryset(self):
-        return Order.objects.filter(user=self.request.user, is_deleted=False)
+        queryset = Order.objects.filter(user=self.request.user, is_deleted=False)
+
+        # status 파라미터가 있으면 필터링(OrderItem의 상태 기준)
+        status_param = self.request.query_params.get('status')
+        if status_param:
+            queryset = queryset.filter(order_items__order_status=status_param).distinct()
+        return queryset
 
     def get_serializer_class(self):
         if self.action == 'create':
             return OrderCreateSerializer
+        elif self.action == 'list': # list 액션 추가 
+            return OrderListSerializer
         return OrderSerializer
 
     def create(self, request, *args, **kwargs):
@@ -23,4 +53,4 @@ class OrderViewSet(viewsets.GenericViewSet):
         order = serializer.save()
         
         # Response(201 Created) body construction handled by serializer.to_representation
-        return Response(serializer.data, status=status.HTTP_201_CREATED)
+        return Response(serializer.data, status=status.HTTP_201_CREATED) 


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #55

## #️⃣ 작업 내용

> orders/serializers.py에 OrderListSerializer 추가(API 명세서에서 요구하는 응답 형식을 맞추기 위함), 내부적으로 사용하는 id 필드를 클라이언트에게는 order_id라는 이름으로 보여주도록 설정
> orders/views.py에 커서 기반 페이지네이션 구현(OrderCursorPagination 클래스 정의), 최신 주문이 먼저 보이도록 created_at 기준 내림차순 정렬 적용, 다음 페이지 주소 전체를 주는 대신에 next_cursor 값만 깔끔하게 추출해서 응답하도록 만들었다. 
> orders/views.py에 ViewSet 기능 확장(OrderViewSet에 목록 조회 기능 추가), ListModelMixin을 상속받아 GET /api/v1/orders 요청을 처리하게 했다, status 파라미터가 들어오면 해당 주문 상태를 포함하는 주문들만 골라서 보여주도록 필터링 로직을 넣었다, 목록 조회 요청이 들어오면 자동으로 위에서 만든 OrderListSerializer와 OrderCursorPagination을 사용하도록 연결. 

