### PR TITLE
주문 취소

### DIFF
--- a/orders/urls.py
+++ b/orders/urls.py
@@ -7,4 +7,4 @@ router.register('orders', OrderViewSet, basename='order')
 
 urlpatterns = [
     path('', include(router.urls)),
-]
+] 

--- a/orders/views.py
+++ b/orders/views.py
@@ -3,7 +3,7 @@ from rest_framework.response import Response
 from rest_framework import mixins
 from rest_framework.pagination import CursorPagination
 from .models import Order
-from .serializers import OrderCreateSerializer, OrderSerializer, OrderListSerializer, OrderDetailSerializer
+from .serializers import OrderCreateSerializer, OrderSerializer, OrderListSerializer, OrderDetailSerializer, OrderCancelSerializer
 
 class OrderCursorPagination(CursorPagination):
     ordering = '-created_at'
@@ -24,7 +24,7 @@ class OrderCursorPagination(CursorPagination):
             'next_cursor': next_cursor,
         })
 
-class OrderViewSet(mixins.ListModelMixin, mixins.RetrieveModelMixin,viewsets.GenericViewSet):
+class OrderViewSet(mixins.ListModelMixin, mixins.RetrieveModelMixin, mixins.UpdateModelMixin, viewsets.GenericViewSet):
     permission_classes = [permissions.IsAuthenticated]
     pagination_class = OrderCursorPagination # 위에서 만든 클래스 연결 
 
@@ -44,6 +44,8 @@ class OrderViewSet(mixins.ListModelMixin, mixins.RetrieveModelMixin,viewsets.Gen
             return OrderListSerializer
         elif self.action == 'retrieve':
             return OrderDetailSerializer 
+        elif self.action == 'partial_update':
+            return OrderCancelSerializer
         return OrderSerializer
 
     def create(self, request, *args, **kwargs):


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #67

## #️⃣ 작업 내용

> orders/serializers.py에 OrderCancelSerializer를 새로 추가하여 취소 로직 전달 : 유효성 검사, 데이터 처리, 응답 커스터마이징 
> orders/views.py에 OrderViewSet 기능 확장 : UpdateModelMixin 추가(patch 요청을 처리할 수 있도록 상속 클래스 추가), Serializer 연결(partial_update(patch) 액션이 들어오면 자동으로 위에서 만든 OrderCancelSerializer를 사용할 수 있도록 연결)

