### PR TITLE
Test/fitting api

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -162,21 +162,18 @@ CACHES = {
 # =============================================================================
 
 # Broker - RabbitMQ (primary) or Redis (fallback)
-CELERY_BROKER_URL = os.getenv(
-    'CELERY_BROKER_URL',
-    f'amqp://{os.getenv("RABBITMQ_USER", "guest")}:{os.getenv("RABBITMQ_PASSWORD", "guest")}@{os.getenv("RABBITMQ_HOST", "localhost")}:{os.getenv("RABBITMQ_PORT", "5672")}//'
-)
+CELERY_BROKER_URL = 'redis://localhost:6379/0'
 
 # Result backend - Redis
-CELERY_RESULT_BACKEND = os.getenv('CELERY_RESULT_BACKEND', REDIS_URL)
+CELERY_RESULT_BACKEND = 'redis://localhost:6379/0'
 
 CELERY_ACCEPT_CONTENT = ['json']
 CELERY_TASK_SERIALIZER = 'json'
 CELERY_RESULT_SERIALIZER = 'json'
-CELERY_TIMEZONE = TIME_ZONE
+CELERY_TIMEZONE = 'Asia/Seoul'
 CELERY_TASK_TRACK_STARTED = True
 CELERY_TASK_TIME_LIMIT = 30 * 60  # 30 minutes
-
+CELERY_TASK_ALWAYS_EAGER = False
 
 # =============================================================================
 # OpenSearch Configuration

--- a/fittings/tasks.py
+++ b/fittings/tasks.py
@@ -16,7 +16,7 @@ def process_fitting_task(self, fitting_id):
         result = service.create_fitting_and_wait(
             model_image_url=fitting.user_image.user_image_url,
             product_image_url=fitting.product.product_image_url,
-            category=service.map_category(fitting.product.size_group.category)
+            category=service.map_category(fitting.product.category)
         )
 
         if result.status == 'completed':

--- a/fittings/views.py
+++ b/fittings/views.py
@@ -7,7 +7,7 @@ from .serializers import FittingImageSerializer, FittingStatusSerializer
 from .tasks import process_fitting_task
 
 class FittingRequestView(APIView):
-   def post(self, request):
+    def post(self, request):
         # 1. 시리얼라이저로 데이터 검증 (product, user_image 존재 여부 등 체크)
         serializer = FittingImageSerializer(data=request.data)
         
@@ -15,9 +15,8 @@ class FittingRequestView(APIView):
             # 2. DB 레코드 생성 (상태는 PENDING)
             fitting = serializer.save(fitting_image_status=FittingImage.Status.PENDING)
             
-            # 3. 프론트에서 보낸 user_image_url을 꺼내서 Celery에 함께 전달
-            user_image_url = request.data.get('user_image_url')
-            process_fitting_task.delay(fitting.id, user_image_url)
+            # 3. Celery 태스크 실행 (fitting_id만 전달, 나머지는 DB에서 조회)
+            process_fitting_task.delay(fitting.id)
             
             return Response(serializer.data, status=status.HTTP_201_CREATED)
         


### PR DESCRIPTION
## #️⃣ 연관된 이슈

#53 

## #️⃣ 작업 내용

fittings/views.py 에서는 인자를 두 개 보내지만 fittings/tasks.py에서는 인자를 하나만 받기 때문에 오류가 계속 발생했었고 이것을 해결하기 위해 뷰 파일에서 인자를 하나로 수정했습니다.

태스크가 즉시 동기적으로 실행되고 있어서 Redis 큐에 추가되지 않습니다. 이래서 Celery 워커가 "received" 메시지를 보여주지 않아 문제가 됐습니다. 그래서 config/settings.py 에서 CELERY_TASK_ALWAYS_EAGER = False 을 추가해서 해결했습니다.

## #️⃣ 테스트 결과
원본 사진 : https://i.pinimg.com/736x/58/87/bd/5887bd5198e2bf31010a848b5727b427.jpg
피팅 사진 : https://cdn.fashn.ai/b13936cd-9b90-47d7-bd7a-8764e9973ce7/output_0.png
