### PR TITLE
사용자 필수 정보 등록 스웨거 5차 수정 

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -32,6 +32,7 @@ INSTALLED_APPS = [
     'django.contrib.staticfiles',
     # Third party
     'rest_framework',
+    'drf_spectacular',
     'rest_framework_simplejwt.token_blacklist',
     'django_prometheus',
     'storages',
@@ -216,6 +217,7 @@ GOOGLE_APPLICATION_CREDENTIALS = os.getenv('GOOGLE_APPLICATION_CREDENTIALS', '')
 # =============================================================================
 
 REST_FRAMEWORK = {
+    'DEFAULT_SCHEMA_CLASS': 'drf_spectacular.openapi.AutoSchema',
     'DEFAULT_PERMISSION_CLASSES': [
         'rest_framework.permissions.IsAuthenticated',
     ],
@@ -357,3 +359,11 @@ CORS_ALLOW_HEADERS = [
     'x-csrftoken',
     'x-requested-with',
 ]
+
+SPECTACULAR_SETTINGS = {
+    'TITLE': 'Team_G API',
+    'DESCRIPTION': 'Team_G Shopping Agent Backend API Documentation',
+    'VERSION': '1.0.0',
+    'SERVE_INCLUDE_SCHEMA': False,
+    # Optional: Grouping or other settings
+}

--- a/config/urls.py
+++ b/config/urls.py
@@ -7,7 +7,12 @@ from django.urls import path, include
 from django.http import JsonResponse
 from django.conf import settings
 from django.conf.urls.static import static
-
+from django.urls import path
+from drf_spectacular.views import (
+    SpectacularAPIView, 
+    SpectacularRedocView, 
+    SpectacularSwaggerView
+)
 
 def health_check(request):
     """Health check endpoint."""
@@ -23,4 +28,7 @@ urlpatterns = [
     path('api/v1/', include('analyses.urls')),
     path('api/v1/', include('fittings.urls')),
     path('', include('analyses.urls')),
+    path('api/schema/', SpectacularAPIView.as_view(), name='schema'),
+    path('api/schema/swagger-ui/', SpectacularSwaggerView.as_view(url_name='schema'), name='swagger-ui'),
+    path('api/schema/redoc/', SpectacularRedocView.as_view(url_name='schema'), name='redoc'),
 ] + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,6 +24,7 @@ transformers==4.47.1
 torch==2.2.2
 httpx>=0.25.0,<0.28.0
 fashion-clip==0.2.2
+drf-spectacular==0.27.1
 
 # Observability - Logging (Loki)
 python-logging-loki==0.3.1

--- a/users/serializers.py
+++ b/users/serializers.py
@@ -31,8 +31,7 @@ class UserRegisterSerializer(serializers.ModelSerializer):
 
 class UserOnboardingSerializer(serializers.ModelSerializer):
     # 프론트에서 user_email로 보낸다니 source를 이용해 매핑 가능
-    user_email = serializers.EmailField(source='email', required=True)
-    
+    user_email = serializers.EmailField(source='email', required=True) 
     user_id = serializers.IntegerField(source='id', read_only=True)
     user_name = serializers.CharField(source='username', read_only=True)
     updated_at = serializers.DateTimeField(read_only=True) 
@@ -40,13 +39,8 @@ class UserOnboardingSerializer(serializers.ModelSerializer):
     class Meta:
         model = User
         fields = [
-            'user_email', 
-            'address', 
-            'phone_number', 
-            'payment', 
-            "user_id", 
-            "user_name", 
-            "updated_at"
+            'user_email', 'address', 'phone_number', 
+            'payment', "user_id", "user_name", "updated_at"
         ]
 
 class UserProfileSerializer(serializers.ModelSerializer):

--- a/users/views.py
+++ b/users/views.py
@@ -3,6 +3,7 @@ from rest_framework.permissions import IsAuthenticated, AllowAny
 from rest_framework.response import Response
 from rest_framework import status
 from rest_framework_simplejwt.tokens import RefreshToken
+from drf_spectacular.utils import extend_schema, OpenApiExample, OpenApiResponse
 
 from .serializers import UserOnboardingSerializer, UserProfileSerializer, UserRegisterSerializer
 
@@ -32,6 +33,43 @@ class UserRegisterView(APIView):
 class UserOnboardingView(APIView):
     permission_classes = [IsAuthenticated]
 
+    @extend_schema(
+        summary="사용자 필수 정보 등록 (온보딩)",
+        description="신규 사용자의 이메일, 주소, 결제 수단, 전화번호를 등록합니다.",
+        request=UserOnboardingSerializer,
+        responses={
+            200: UserOnboardingSerializer,
+            400: OpenApiResponse(description="Invalid request data (필수 필드 누락, 형식 오류 등)"),
+            401: OpenApiResponse(description="Unauthorized (인증 토큰 유효하지 않음)"),
+            500: OpenApiResponse(description="Internal server error (DB 저장 오류 등)"),
+        },
+        examples=[
+            OpenApiExample(
+                "온보딩 요청 예시",
+                value={
+                    "user_email": "string",
+                    "address": "string",
+                    "payment": "card",
+                    "phone_number": "string"
+                },
+                request_only=True,
+            ),
+            OpenApiExample(
+                "온보딩 성공 응답 예시",
+                value={
+                    "user_id": 1,
+                    "user_name": "string",
+                    "user_email": "string",
+                    "address": "string",
+                    "payment": "card",
+                    "phone_number": "string",
+                    "updated_at": "2026-01-10T12:34:56Z"
+                },
+                response_only=True,
+            )
+        ]
+    )
+    
     def patch(self, request):
         # instance=request.user를 넘겨주면 '생성'이 아닌 '수정' 모드로 동작합니다.
         serializer = UserOnboardingSerializer(


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #117

## #️⃣ 작업 내용

> users/serializers.py : UserOnboardingSerializer가 API 명세에 명시된 필드(user_email, address, payment, phone_number)를 모두 포함하고 있다
source='email' 등을 통해 실제 데이터베이스 필드와 정확히 연결되어 있으며, 응답 시 필요한 user_id, user_name, updated_at 필드도 read_only로 잘 정의되어 있다.

> users/views.py : @extend_schema 데코레이터를 통해 스웨거 문서화가 세밀하게 적용
요청 본문 형식, 200/400/401/500 응답 케이스, 그리고 **실제 데이터 예시(Examples)**까지 모두 포함되어 있어 프론트엔드 개발자가 참고하기 매우 좋은 상태
필요한 모든 라이브러리(rest_framework, drf_spectacular 등)의 임포트도 정상적으로 완료