### PR TITLE
사용자 필수 정보 등록을 제외한 전체 api에 스웨거 달기 

### DIFF
--- a/users/views.py
+++ b/users/views.py
@@ -12,6 +12,7 @@ class UserRegisterView(APIView):
     """회원가입 API"""
     permission_classes = [AllowAny]
 
+    @extend_schema(tags=["Users"], summary="회원가입", description="신규 사용자를 등록하고 인증 토큰을 발급합니다.")
     def post(self, request):
         serializer = UserRegisterSerializer(data=request.data)
         if serializer.is_valid(raise_exception=True):
@@ -34,6 +35,7 @@ class UserOnboardingView(APIView):
     permission_classes = [IsAuthenticated]
 
     @extend_schema(
+        tags=["Users"],
         summary="사용자 필수 정보 등록 (온보딩)",
         description="신규 사용자의 이메일, 주소, 결제 수단, 전화번호를 등록합니다.",
         request=UserOnboardingSerializer,
@@ -89,11 +91,13 @@ class UserOnboardingView(APIView):
 class UserMeView(APIView):
     permission_classes = [IsAuthenticated]
 
+    @extend_schema(tags=["Users"], summary="사용자 정보 조회", description="현재 로그인한 사용자의 프로필 정보를 조회합니다.")
     def get(self, request):
         """사용자 정보 조회"""
         serializer = UserProfileSerializer(request.user)
         return Response(serializer.data, status=status.HTTP_200_OK)
 
+    @extend_schema(tags=["Users"], summary="사용자 정보 수정", description="현재 로그인한 사용자의 프로필 정보를 수정합니다.")
     def patch(self, request):
         """사용자 정보 수정"""
         # 수정 시에도 UserProfileSerializer를 사용할지, 별도 Serializer를 사용할지 결정 필요


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #120

## #️⃣ 작업 내용

> 1. 설정 (Configuration)
수정: config/settings.py

필요 시 SPECTACULAR_SETTINGS를 세분화하여 업데이트합니다. (예: 태그 추가, 담당자 연락처 정보 등)

> 2. 사용자 앱 (Users App)
[수정] users/views.py

UserRegisterView에 @extend_schema 데코레이터 추가.

UserMeView (GET 및 PATCH 메소드)에 @extend_schema 추가.

모든 뷰에 ["Users"]와 같은 직관적인 태그가 포함되었는지 확인.

> 3. 피팅 앱 (Fittings App)
[수정] fittings/views.py

다음 뷰들에 @extend_schema 추가:

UserImageUploadView

FittingRequestView

FittingStatusView

FittingResultView

모든 기능을 ["Fittings"] 태그로 그룹화.

> 4. 분석 앱 (Analyses App)
[수정] analyses/views.py

다음 뷰들에 @extend_schema 추가:

UploadedImageView (GET 및 POST)

ImageAnalysisView (POST 및 PATCH)

AnalysisRefineStatusView

ImageAnalysisStatusView

ImageAnalysisResultView

UploadedImageHistoryView

모든 기능을 ["Analyses"] 태그로 그룹화.

> 5. 주문 앱 (Orders App)
[수정] orders/views.py

OrderViewSet에 @extend_schema_view를 사용하여 문서화 정보 추가.

다음 뷰들에 @extend_schema 추가:

CartItemListCreateView

CartItemDeleteView

모든 기능을 ["Orders"] 태그로 그룹화.

