### PR TITLE
refactor: 히스토리 조회 api 수정

### DIFF
--- a/analyses/serializers.py
+++ b/analyses/serializers.py
@@ -540,6 +540,18 @@ class HistoryItemSerializer(serializers.ModelSerializer):
                 'fitting_image_url': fitting.fitting_image_url,
             }
 
+        # 사이즈 목록 조회 (selected_product 포함)
+        sizes = []
+        for size_code in product.size_codes.filter(is_deleted=False):
+            # 해당 사이즈의 SelectedProduct 조회
+            selected = size_code.selections.filter(is_deleted=False).first()
+            sizes.append({
+                'size_code_id': size_code.id,
+                'size_value': size_code.size_value,
+                'inventory': selected.selected_product_inventory if selected else 0,
+                'selected_product_id': selected.id if selected else None,
+            })
+
         return {
             'product_id': product.id,
             'product': {
@@ -549,6 +561,7 @@ class HistoryItemSerializer(serializers.ModelSerializer):
                 'selling_price': product.selling_price,
                 'image_url': product.product_image_url,
                 'product_url': product.product_url,
+                'sizes': sizes,
             },
             'fitting': fitting_data,
         }

--- a/analyses/tasks/refine.py
+++ b/analyses/tasks/refine.py
@@ -299,17 +299,17 @@ def refine_single_object(
             logger.info(f"Generated detailed text embedding: '{search_text}'")
 
         # 5. 임베딩 결합 - 요청 유형에 따라 비중 조절
-        # - 속성 변경 요청 (색상, 패턴, 스타일 등): 텍스트 80% + 이미지 20% (모양만 참고)
+        # - 속성 변경 요청 (색상, 패턴, 스타일 등): 이미지 50% + 텍스트 50% (형태 유지하면서 속성 변경)
         # - 단순 재검색 (비슷한 거 찾아줘): 이미지 100%
         if has_attribute_change and text_embedding is not None:
             if image_embedding is not None:
-                # 속성 변경: 텍스트 중심 (80%) + 이미지 형태 참고 (20%)
+                # 속성 변경: 이미지 형태 (50%) + 텍스트 속성 (50%)
                 image_arr = np.array(image_embedding)
                 text_arr = np.array(text_embedding)
                 combined = 0.5 * image_arr + 0.5 * text_arr
                 combined = combined / np.linalg.norm(combined)
                 embedding = combined.tolist()
-                logger.info(f"Attribute change: text 80% + image 20%")
+                logger.info(f"Attribute change: image 50% + text 50%")
             else:
                 # 이미지 없으면 텍스트만
                 embedding = text_embedding

--- a/analyses/views.py
+++ b/analyses/views.py
@@ -697,6 +697,8 @@ class UploadedImageHistoryView(APIView):
         ).prefetch_related(
             'product_mappings',
             'product_mappings__product',
+            'product_mappings__product__size_codes',
+            'product_mappings__product__size_codes__selections',
         ).order_by('-id')
 
         # 4. 커서 기반 페이지네이션


### PR DESCRIPTION
## #️⃣ 연관된 이슈

#122 

프론트에서 히스토리 조회시 사이즈와 selected_product_id가 누락되어 백엔드 api에서 추가 
