### PR TITLE
[FIX] 리팩토링 이후 일부 analyses api에 대해 트레이싱에서 버그가 생기던 문제 해결

### DIFF
--- a/analyses/apps.py
+++ b/analyses/apps.py
@@ -7,9 +7,10 @@ class AnalysesConfig(AppConfig):
     verbose_name = 'Image Analyses'
 
     def ready(self):
-        """Initialize OpenTelemetry tracing when Django starts."""
-        try:
-            from config.tracing import init_tracing
-            init_tracing(service_name="team-g-backend")
-        except ImportError:
-            pass  # Tracing packages not installed
+        """App initialization hook.
+
+        Note: Tracing is initialized separately:
+        - Django web server: config/wsgi.py
+        - Celery worker: config/celery.py (via celeryd_init signal)
+        """
+        pass

--- a/config/tracing.py
+++ b/config/tracing.py
@@ -69,15 +69,13 @@ def init_tracing(service_name: str = "team-g-backend"):
             agent_port=jaeger_port,
         )
 
-        # Set up TracerProvider with BatchSpanProcessor
-        # Use small batch size to avoid UDP "Message too long" errors
+        # Set up TracerProvider with BatchSpanProcessor for efficient export
         provider = TracerProvider(resource=resource)
-        span_processor = BatchSpanProcessor(
-            jaeger_exporter,
-            max_export_batch_size=10,  # Small batches for UDP size limit
-            schedule_delay_millis=1000,  # Export every 1 second
-        )
-        provider.add_span_processor(span_processor)
+
+        # Add Jaeger exporter with batch processor
+        jaeger_processor = BatchSpanProcessor(jaeger_exporter)
+        provider.add_span_processor(jaeger_processor)
+
         trace.set_tracer_provider(provider)
 
         # Auto-instrumentation for Django


### PR DESCRIPTION
#️⃣ 연관된 이슈
#133

#️⃣ 작업 내용
[FIX] 리팩토링 이후 일부 analyses api에 대해 트레이싱에서 버그가 생기던 문제 해결

문제 원인:
- analyses/apps.py에서 Django 앱 시작 시 init_tracing(service_name="team-g-backend")가 호출되어 _tracing_initialized 플래그가 True로 설정됨
- Celery worker 시작 시 celeryd_init.connect 시그널에서 init_tracing(service_name="team-g-celery-worker") 호출이 무시됨
- 결과적으로 Celery worker의 트레이스가 Jaeger에 표시되지 않음

수정 내용:  
1. analyses/apps.py: 중복 init_tracing() 호출 제거
2. analyses/utils.py: @lru_cache 제거 및 TracingContext 개선 
3. config/tracing.py: BatchSpanProcessor 설정 단순화

#️⃣ 테스트 결과

- Jaeger UI에서 team-g-celery-worker 서비스 정상 표시 확인
- 전체 파이프라인 트레이스 정상 동작 (30 spans)
- process_single_item → extract_attributes_claude → generate_embedding_fashionclip → search_opensearch_knn → rerank_claude → save_results_to_db

#️⃣ 스크린샷 (선택)

Jaeger UI: team-g-celery-worker (이미지 업로드 -> 상품리랭킹 까지의 과정 )
<img width="1920" height="966" alt="Screenshot 2026-01-18 at 4 34 01 PM" src="https://github.com/user-attachments/assets/d578a9cf-f400-4957-883f-29fee834d7d1" />


#️⃣ 리뷰 요구사항 (선택)
- analyses/utils.py의 TracingContext 클래스가 context manager lifecycle을 올바르게 관리하는지 확인 부탁드립니다.

📎 참고 자료 (선택)

트레이싱 초기화 위치:
- Django 웹서버: config/wsgi.py
- Celery worker: config/celery.py (via celeryd_init signal)
