### PR TITLE
feat: 업로드 이미지 목록 API에 analysis_id 추가 

### DIFF
--- a/analyses/tasks/analysis.py
+++ b/analyses/tasks/analysis.py
@@ -2,9 +2,10 @@
 Image Analysis Tasks - 이미지 분석 파이프라인.
 
 리팩토링:
-- storage.py: GCS 업로드/다운로드
-- image_processing.py: 이미지 크롭/변환
-- db_operations.py: DB 저장 로직
+- 상수 모듈 활용 (constants.py)
+- 공통 유틸리티 활용 (utils.py)
+- 장문 함수 분리 (_process_detected_item → 6개 헬퍼)
+- Product 생성 로직 통합
 
 Pipeline:
 1. Receive image analysis request
@@ -19,37 +20,39 @@ Pipeline:
 10. Update status in Redis
 """
 
+import io
 import base64
 import logging
+from datetime import datetime
 from typing import Optional
 
 from celery import shared_task, chord
+from django.conf import settings
+from PIL import Image
+from google.cloud import storage
 
 from services.vision_service import get_vision_service, DetectedItem
 from services.embedding_service import get_embedding_service
 from services.opensearch_client import OpenSearchService
 from services.redis_service import get_redis_service
 from services.metrics import (
+    ANALYSIS_TOTAL,
     ANALYSIS_DURATION,
     ANALYSIS_IN_PROGRESS,
+    ANALYSES_COMPLETED_TOTAL,
+    PRODUCT_MATCHES_TOTAL,
     push_metrics,
 )
 
-from analyses.constants import SearchConfig
-from analyses.utils import normalize_category, create_span
-
-# 새 모듈에서 import
-from analyses.tasks.storage import (
-    download_image,
-    upload_cropped_image,
-    upload_cropped_image_with_span,
+from analyses.constants import (
+    CATEGORY_MAPPING,
+    SearchConfig,
+    ImageConfig,
 )
-from analyses.tasks.image_processing import crop_image
-from analyses.tasks.db_operations import (
-    update_analysis_status_db,
-    save_analysis_results,
-    update_metrics_on_success,
-    update_metrics_on_failure,
+from analyses.utils import (
+    normalize_category,
+    normalize_bbox,
+    create_span,
 )
 
 
@@ -103,7 +106,7 @@ def process_image_analysis(
             redis_service.update_analysis_running(analysis_id, progress=0)
             logger.info(f"Starting analysis {analysis_id}")
 
-            # Step 1: Get image bytes
+            # Step 1: Get image bytes (직접 전달받았으면 다운로드 생략)
             if image_b64:
                 with create_span(TRACER_NAME, "1_decode_image_bytes") as span:
                     span.set("source", "direct_bytes")
@@ -116,7 +119,7 @@ def process_image_analysis(
                     span.set("service", "google_cloud_storage")
                     redis_service.set_analysis_progress(analysis_id, 10)
                     with ANALYSIS_DURATION.labels(stage='download_image').time():
-                        image_bytes = download_image(image_url)
+                        image_bytes = _download_image(image_url)
                     span.set("image.size_bytes", len(image_bytes))
 
             # Step 2: Detect objects with Vision API
@@ -134,7 +137,7 @@ def process_image_analysis(
 
             if not detected_items:
                 redis_service.update_analysis_done(analysis_id, {'items': []})
-                update_analysis_status_db(analysis_id, 'DONE')
+                _update_analysis_status_db(analysis_id, 'DONE')
                 ctx.set("result", "no_items_detected")
                 return {'analysis_id': analysis_id, 'items': []}
 
@@ -182,7 +185,7 @@ def process_image_analysis(
         except Exception as e:
             logger.error(f"Analysis {analysis_id} failed: {e}")
             redis_service.update_analysis_failed(analysis_id, str(e))
-            update_analysis_status_db(analysis_id, 'FAILED')
+            _update_analysis_status_db(analysis_id, 'FAILED')
             ctx.set("error", str(e))
             raise self.retry(exc=e)
 
@@ -277,15 +280,15 @@ def analysis_complete_callback(
                 span.set("records_count", len(valid_results))
                 redis_service.set_analysis_progress(analysis_id, 90)
                 with ANALYSIS_DURATION.labels(stage='save_results').time():
-                    save_analysis_results(analysis_id, valid_results, user_id)
+                    _save_analysis_results(analysis_id, valid_results, user_id)
 
             # 완료 상태 업데이트
             with create_span(TRACER_NAME, "8_update_status"):
                 redis_service.update_analysis_done(analysis_id, {'items': valid_results})
-                update_analysis_status_db(analysis_id, 'DONE')
+                _update_analysis_status_db(analysis_id, 'DONE')
 
             # Metrics 업데이트
-            update_metrics_on_success(valid_results)
+            _update_metrics(valid_results)
             ANALYSIS_IN_PROGRESS.dec()
 
             logger.info(f"Analysis {analysis_id} completed: {len(valid_results)}/{total_items} items processed")
@@ -303,11 +306,11 @@ def analysis_complete_callback(
         except Exception as e:
             logger.error(f"Failed to complete analysis {analysis_id}: {e}")
             redis_service.update_analysis_failed(analysis_id, str(e))
-            update_analysis_status_db(analysis_id, 'FAILED')
+            _update_analysis_status_db(analysis_id, 'FAILED')
             ctx.set("status", "FAILED")
             ctx.set("error", str(e))
 
-            update_metrics_on_failure()
+            ANALYSIS_TOTAL.labels(status='failed').inc()
             ANALYSIS_IN_PROGRESS.dec()
             push_metrics()
 
@@ -337,7 +340,7 @@ def process_detected_item_task(
 
 
 # =============================================================================
-# Pipeline Helpers
+# Helper Functions - 객체 처리 파이프라인
 # =============================================================================
 
 def _process_detected_item(
@@ -361,7 +364,7 @@ def _process_detected_item(
         with create_span(TRACER_NAME, "1_crop_image") as span:
             span.set("item.index", item_index)
             span.set("item.category", detected_item.category)
-            cropped_bytes, pixel_bbox = crop_image(image_bytes, detected_item)
+            cropped_bytes, pixel_bbox = _crop_image(image_bytes, detected_item)
 
         # 현재 트레이스 컨텍스트 캡처 (스레드 전파용)
         current_context = otel_context.get_current()
@@ -379,7 +382,7 @@ def _process_detected_item(
             # GCS 업로드 (백그라운드)
             gcs_future = executor.submit(
                 run_with_context,
-                upload_cropped_image_with_span,
+                _upload_to_gcs_with_span,
                 image_bytes=cropped_bytes,
                 analysis_id=analysis_id,
                 item_index=item_index,
@@ -428,6 +431,23 @@ def _process_detected_item(
         return None
 
 
+def _upload_to_gcs_with_span(
+    image_bytes: bytes,
+    analysis_id: str,
+    item_index: int,
+    category: str,
+) -> Optional[str]:
+    """GCS 업로드 (트레이싱 포함, 병렬 실행용)."""
+    with create_span(TRACER_NAME, "2_upload_to_gcs") as span:
+        span.set("service", "google_cloud_storage")
+        return _upload_to_gcs(
+            image_bytes=image_bytes,
+            analysis_id=analysis_id,
+            item_index=item_index,
+            category=category,
+        )
+
+
 def _extract_attributes(cropped_bytes: bytes, category: str) -> Optional[object]:
     """Claude Vision으로 속성 추출."""
     from services.gpt4v_service import get_gpt4v_service
@@ -453,7 +473,7 @@ def _extract_attributes(cropped_bytes: bytes, category: str) -> Optional[object]
 
 
 def _generate_embedding(cropped_bytes: bytes) -> list[float]:
-    """FashionCLIP 임베딩 생성."""
+    """FashionCLIP 임베딩 생성 (병렬 실행용)."""
     with create_span(TRACER_NAME, "3_generate_embedding_fashionclip") as span:
         span.set("service", "marqo_fashionclip")
         span.set("embedding_dim", 512)
@@ -469,12 +489,14 @@ def _search_opensearch(
     attributes: Optional[object],
 ) -> list[dict]:
     """OpenSearch k-NN 검색."""
+    # 카테고리 정규화 및 속성 추출
     search_category = normalize_category(category)
     detected_brand = attributes.brand if attributes else None
     detected_color = attributes.color if attributes else None
     detected_secondary = attributes.secondary_color if attributes else None
     detected_item_type = attributes.item_type if attributes else None
 
+    # OpenSearch 검색
     with create_span(TRACER_NAME, "4_search_opensearch_knn") as span:
         span.set("service", "opensearch")
         span.set("search.category", search_category)
@@ -537,6 +559,7 @@ def _format_item_result(
     attributes: Optional[object],
 ) -> dict:
     """검출 결과 포맷팅."""
+    # 상위 매칭 결과 정리
     top_matches = []
     for match in search_results[:SearchConfig.FINAL_RESULTS]:
         top_matches.append({
@@ -556,6 +579,7 @@ def _format_item_result(
         'matches': top_matches,
     }
 
+    # 속성 정보 추가
     if attributes:
         result['attributes'] = {
             'color': attributes.color,
@@ -567,3 +591,296 @@ def _format_item_result(
         }
 
     return result
+
+
+# =============================================================================
+# Helper Functions - 공통 유틸리티
+# =============================================================================
+
+def _update_analysis_status_db(analysis_id: str, status: str):
+    """DB의 ImageAnalysis 상태 업데이트."""
+    from analyses.models import ImageAnalysis
+    try:
+        analysis = ImageAnalysis.objects.get(id=analysis_id)
+        analysis.image_analysis_status = status
+        analysis.save(update_fields=['image_analysis_status', 'updated_at'])
+    except ImageAnalysis.DoesNotExist:
+        logger.error(f"ImageAnalysis {analysis_id} not found for status update")
+
+
+def _update_metrics(valid_results: list[dict]):
+    """분석 완료 메트릭 업데이트."""
+    ANALYSIS_TOTAL.labels(status='success').inc()
+    ANALYSES_COMPLETED_TOTAL.inc()
+
+    for result in valid_results:
+        category = result.get('category', 'unknown')
+        match_count = len(result.get('matches', []))
+        for _ in range(match_count):
+            PRODUCT_MATCHES_TOTAL.labels(category=category).inc()
+
+
+def _download_image(image_url: str) -> bytes:
+    """Download image from URL or local file path."""
+    import os
+
+    # Convert GCS HTTPS URL to gs:// format
+    if 'storage.googleapis.com' in image_url:
+        parts = image_url.split('storage.googleapis.com/')
+        if len(parts) > 1:
+            image_url = 'gs://' + parts[1]
+
+    if image_url.startswith('gs://'):
+        parts = image_url[5:].split('/', 1)
+        bucket_name = parts[0]
+        blob_name = parts[1] if len(parts) > 1 else ''
+
+        client = storage.Client()
+        bucket = client.bucket(bucket_name)
+        blob = bucket.blob(blob_name)
+
+        return blob.download_as_bytes()
+
+    elif image_url.startswith('/media/'):
+        local_path = settings.BASE_DIR / image_url.lstrip('/')
+        if not os.path.exists(local_path):
+            raise FileNotFoundError(f"Local file not found: {local_path}")
+        with open(local_path, 'rb') as f:
+            return f.read()
+
+    elif image_url.startswith('http://') or image_url.startswith('https://'):
+        import requests
+        response = requests.get(image_url, timeout=30)
+        response.raise_for_status()
+        return response.content
+
+    else:
+        raise ValueError(f"Unsupported URL format: {image_url}")
+
+
+def _upload_to_gcs(
+    image_bytes: bytes,
+    analysis_id: str,
+    item_index: int,
+    category: str,
+) -> Optional[str]:
+    """Upload cropped image to GCS."""
+    try:
+        bucket_name = settings.GCS_BUCKET_NAME
+        credentials_file = settings.GCS_CREDENTIALS_FILE
+
+        if not bucket_name or not credentials_file:
+            logger.warning("GCS not configured, skipping upload")
+            return None
+
+        client = storage.Client.from_service_account_json(credentials_file)
+        bucket = client.bucket(bucket_name)
+
+        timestamp = datetime.now().strftime('%Y%m%d_%H%M%S')
+        filename = f"cropped/{analysis_id}/{timestamp}_{item_index}_{category}.jpg"
+
+        blob = bucket.blob(filename)
+        blob.upload_from_string(image_bytes, content_type='image/jpeg')
+
+        gcs_url = f"https://storage.googleapis.com/{bucket_name}/{filename}"
+        logger.info(f"Uploaded cropped image to GCS: {gcs_url}")
+
+        return gcs_url
+
+    except Exception as e:
+        logger.error(f"Failed to upload to GCS: {e}")
+        return None
+
+
+def _crop_image(
+    image_bytes: bytes,
+    item: DetectedItem,
+    padding_ratio: float = None,
+) -> tuple[bytes, dict]:
+    """Crop detected item from image with padding."""
+    if padding_ratio is None:
+        padding_ratio = ImageConfig.BBOX_PADDING_RATIO
+
+    image = Image.open(io.BytesIO(image_bytes))
+    width, height = image.size
+
+    # Convert normalized coordinates (0-1000) to pixels
+    bbox = item.bbox
+    x_min = int(bbox.x_min * width / 1000)
+    y_min = int(bbox.y_min * height / 1000)
+    x_max = int(bbox.x_max * width / 1000)
+    y_max = int(bbox.y_max * height / 1000)
+
+    # 원본 pixel bbox 저장
+    pixel_bbox = {
+        'x_min': x_min,
+        'y_min': y_min,
+        'x_max': x_max,
+        'y_max': y_max,
+        'width': x_max - x_min,
+        'height': y_max - y_min,
+        'image_width': width,
+        'image_height': height,
+    }
+
+    # Add padding
+    bbox_width = x_max - x_min
+    bbox_height = y_max - y_min
+    pad_x = int(bbox_width * padding_ratio)
+    pad_y = int(bbox_height * padding_ratio)
+
+    crop_x_min = max(0, x_min - pad_x)
+    crop_y_min = max(0, y_min - pad_y)
+    crop_x_max = min(width, x_max + pad_x)
+    crop_y_max = min(height, y_max + pad_y)
+
+    cropped = image.crop((crop_x_min, crop_y_min, crop_x_max, crop_y_max))
+
+    output = io.BytesIO()
+    cropped.save(output, format='JPEG', quality=ImageConfig.JPEG_QUALITY)
+    return output.getvalue(), pixel_bbox
+
+
+def _save_analysis_results(
+    analysis_id: str,
+    results: list[dict],
+    user_id: Optional[int],
+):
+    """Save analysis results to MySQL using bulk operations."""
+    from analyses.models import ImageAnalysis, DetectedObject, ObjectProductMapping
+    from products.models import Product
+
+    try:
+        analysis = ImageAnalysis.objects.select_related('uploaded_image').get(id=analysis_id)
+        uploaded_image = analysis.uploaded_image
+
+        # 1단계: 모든 DetectedObject 데이터 준비 및 bulk_create
+        # MySQL에서 bulk_create 후 ID를 얻기 위해 최대 ID 기반 조회 사용
+        max_id_before = DetectedObject.objects.filter(
+            uploaded_image=uploaded_image
+        ).order_by('-id').values_list('id', flat=True).first() or 0
+
+        detected_objects_data = []
+        for result in results:
+            normalized_bbox = _normalize_result_bbox(result.get('bbox', {}))
+            detected_objects_data.append(DetectedObject(
+                uploaded_image=uploaded_image,
+                object_category=result.get('category', 'unknown'),
+                bbox_x1=normalized_bbox['x1'],
+                bbox_y1=normalized_bbox['y1'],
+                bbox_x2=normalized_bbox['x2'],
+                bbox_y2=normalized_bbox['y2'],
+            ))
+
+        DetectedObject.objects.bulk_create(detected_objects_data)
+
+        # bulk_create 후 ID를 가져오기 위해 다시 조회 (max_id 기반)
+        created_objects = list(DetectedObject.objects.filter(
+            uploaded_image=uploaded_image,
+            id__gt=max_id_before
+        ).order_by('id'))
+        logger.info(f"Bulk created {len(created_objects)} DetectedObjects")
+
+        # 2단계: 모든 product_id 수집
+        all_product_ids = set()
+        for result in results:
+            for match in result.get('matches', []):
+                pid = match.get('product_id')
+                if pid:
+                    all_product_ids.add(str(pid))
+
+        # 3단계: 기존 Product 일괄 조회 (두 가지 URL 형식 모두 검색)
+        # - 기존 데이터: https://www.musinsa.com/products/{pid} (사이즈 정보 있음)
+        # - 새 데이터: https://www.musinsa.com/app/goods/{pid}
+        existing_products = {}
+        if all_product_ids:
+            # 두 가지 URL 형식으로 검색, 사이즈 정보를 가진 상품 우선
+            product_urls = []
+            for pid in all_product_ids:
+                product_urls.append(f"https://www.musinsa.com/products/{pid}")
+                product_urls.append(f"https://www.musinsa.com/app/goods/{pid}")
+            # 사이즈 정보가 있는 상품을 우선 선택하기 위해 prefetch
+            from django.db.models import Count, Q
+            products_with_sizes = Product.objects.filter(
+                product_url__in=product_urls
+            ).annotate(
+                size_count=Count('size_codes', filter=Q(size_codes__is_deleted=False))
+            ).order_by('-size_count')  # 사이즈 있는 상품 우선
+
+            for product in products_with_sizes:
+                pid = product.product_url.rstrip('/').split('/')[-1]
+                # 이미 등록된 상품이 없거나, 기존 상품에 사이즈가 없고 새 상품에 있으면 교체
+                if pid not in existing_products:
+                    existing_products[pid] = product
+
+        # 4단계: 없는 Product 일괄 생성
+        new_products_data = []
+        new_product_ids = set()
+        for result in results:
+            for match in result.get('matches', []):
+                pid = str(match.get('product_id', ''))
+                if pid and pid not in existing_products and pid not in new_product_ids:
+                    new_products_data.append(Product(
+                        product_url=f"https://www.musinsa.com/app/goods/{pid}",
+                        brand_name=match.get('brand', 'Unknown') or 'Unknown',
+                        product_name=match.get('name', 'Unknown') or 'Unknown',
+                        category=result.get('category', 'unknown'),
+                        selling_price=int(match.get('price', 0) or 0),
+                        product_image_url=match.get('image_url', '') or '',
+                    ))
+                    new_product_ids.add(pid)
+
+        if new_products_data:
+            created_products = Product.objects.bulk_create(
+                new_products_data, ignore_conflicts=True
+            )
+            logger.info(f"Bulk created {len(created_products)} new Products")
+
+            # 새로 생성된 Product 다시 조회하여 매핑에 추가
+            new_product_urls = [f"https://www.musinsa.com/app/goods/{pid}" for pid in new_product_ids]
+            for product in Product.objects.filter(product_url__in=new_product_urls):
+                pid = product.product_url.rstrip('/').split('/')[-1]
+                existing_products[pid] = product
+
+        # 5단계: ObjectProductMapping 일괄 생성
+        # results와 created_objects는 동일 순서로 생성되었으므로 zip 사용
+        mappings_data = []
+        for obj, result in zip(created_objects, results):
+            for match in result.get('matches', []):
+                pid = str(match.get('product_id', ''))
+                product = existing_products.get(pid)
+                if product:
+                    mappings_data.append(ObjectProductMapping(
+                        detected_object=obj,
+                        product=product,
+                        confidence_score=match.get('score', 0.0),
+                    ))
+
+        if mappings_data:
+            ObjectProductMapping.objects.bulk_create(mappings_data)
+            logger.info(f"Bulk created {len(mappings_data)} ObjectProductMappings")
+
+        # 상태 업데이트
+        analysis.image_analysis_status = ImageAnalysis.Status.DONE
+        analysis.save()
+
+        logger.info(f"Successfully saved {len(results)} results for analysis {analysis_id}")
+
+    except ImageAnalysis.DoesNotExist:
+        logger.error(f"ImageAnalysis {analysis_id} not found")
+    except Exception as e:
+        logger.error(f"Failed to save analysis results: {e}")
+        raise
+
+
+def _normalize_result_bbox(bbox: dict) -> dict:
+    """결과의 bbox를 0-1 범위로 정규화."""
+    img_width = bbox.get('image_width', 1000)
+    img_height = bbox.get('image_height', 1000)
+
+    return {
+        'x1': bbox.get('x_min', 0) / img_width if img_width > 0 else 0,
+        'y1': bbox.get('y_min', 0) / img_height if img_height > 0 else 0,
+        'x2': bbox.get('x_max', 0) / img_width if img_width > 0 else 0,
+        'y2': bbox.get('y_max', 0) / img_height if img_height > 0 else 0,
+    }

--- a/analyses/tasks/db_operations.py
+++ b/analyses/tasks/db_operations.py
@@ -113,13 +113,27 @@ def save_analysis_results(
                 if pid:
                     all_product_ids.add(str(pid))
 
-        # 3단계: 기존 Product 일괄 조회
+        # 3단계: 기존 Product 일괄 조회 (두 가지 URL 형식 모두, 사이즈 있는 상품 우선)
+        # - 기존 데이터: https://www.musinsa.com/products/{pid} (사이즈 있음)
+        # - 새 데이터: https://www.musinsa.com/app/goods/{pid}
         existing_products = {}
         if all_product_ids:
-            product_urls = [f"https://www.musinsa.com/app/goods/{pid}" for pid in all_product_ids]
-            for product in Product.objects.filter(product_url__in=product_urls):
+            from django.db.models import Count, Q
+            product_urls = []
+            for pid in all_product_ids:
+                product_urls.append(f"https://www.musinsa.com/products/{pid}")
+                product_urls.append(f"https://www.musinsa.com/app/goods/{pid}")
+            # 사이즈 있는 상품 우선 선택
+            products_with_sizes = Product.objects.filter(
+                product_url__in=product_urls
+            ).annotate(
+                size_count=Count('size_codes', filter=Q(size_codes__is_deleted=False))
+            ).order_by('-size_count')
+
+            for product in products_with_sizes:
                 pid = product.product_url.rstrip('/').split('/')[-1]
-                existing_products[pid] = product
+                if pid not in existing_products:  # 먼저 등록된 상품 유지 (사이즈 있는 상품)
+                    existing_products[pid] = product
 
         # 4단계: 없는 Product 일괄 생성
         new_products_data = []


### PR DESCRIPTION
## #️⃣ 연관된 이슈

#151 

기존 이미지 분석후에는 analysis_id가 응답으로 와 에이전트가 사용가능 했지만 히스토리는 응답으로 오지 않아서 사용 불가능 했었음

<img width="432" height="934" alt="image" src="https://github.com/user-attachments/assets/3971d0cb-aee1-4c85-b424-b85c6a590888" />

<img width="432" height="199" alt="image" src="https://github.com/user-attachments/assets/5049e359-be43-477e-8066-71931584a1a7" />
